### PR TITLE
Add cache headers for static assets to enable Cloudflare caching

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -6,6 +6,34 @@ app = Flask(__name__)
 app.config.from_object(Config)
 csrf = CSRFProtect(app)
 
+STATIC_EXTENSIONS = frozenset({
+    ".jpg", ".jpeg", ".png", ".gif", ".webp", ".svg", ".ico",
+    ".woff", ".woff2", ".ttf", ".otf", ".eot",
+    ".css", ".js",
+})
+
+IMMUTABLE_MAX_AGE = 60 * 60 * 24 * 365  # 1 year
+
+
+@app.after_request
+def set_cache_headers(response):
+    if response.status_code >= 400:
+        return response
+
+    import os
+    path = response.headers.get("X-Sendfile") or ""
+    _, ext = os.path.splitext(path)
+
+    if not ext:
+        from flask import request
+        _, ext = os.path.splitext(request.path)
+
+    if ext.lower() in STATIC_EXTENSIONS:
+        response.headers["Cache-Control"] = f"public, max-age={IMMUTABLE_MAX_AGE}"
+        response.headers["CDN-Cache-Control"] = f"max-age={IMMUTABLE_MAX_AGE}"
+
+    return response
+
 
 @app.context_processor
 def inject_globals():


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Images load slowly even though the site is proxied through Cloudflare with Cache Reserve enabled. Cache Reserve shows "Current data stored: 0B" because Cloudflare is not caching any assets.

**Root cause:** Flask serves static files without any `Cache-Control` headers by default. Cloudflare relies on origin cache headers to decide what to cache and for how long. Without them, Cloudflare treats every request as uncacheable and passes it straight through to the origin server.

## Solution

Added an `@app.after_request` hook in `app/__init__.py` that sets two cache headers on static asset responses:

- **`Cache-Control: public, max-age=31536000`** — tells browsers and intermediate caches to cache the asset for 1 year.
- **`CDN-Cache-Control: max-age=31536000`** — Cloudflare-specific header that controls Cloudflare's edge cache independently from browser cache policy. This is what populates Cache Reserve.

The hook only applies to responses whose request path ends with a known static file extension (images, fonts, CSS, JS). HTML pages and API routes are not affected.

### File extensions covered

Images: `.jpg`, `.jpeg`, `.png`, `.gif`, `.webp`, `.svg`, `.ico`  
Fonts: `.woff`, `.woff2`, `.ttf`, `.otf`, `.eot`  
Assets: `.css`, `.js`

## What this changes in practice

After deploying, Cloudflare will:

1. Cache static assets at the edge on first request (CF-Cache-Status will change from `DYNAMIC`/`MISS` to `HIT`)
2. Populate Cache Reserve with those assets (the "Current data stored" metric will start growing)
3. Serve subsequent requests from edge cache instead of hitting the origin server

This should dramatically improve image load times since they'll be served from Cloudflare's edge network instead of round-tripping to the origin on every request.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6aa2ac96-fc9f-49b9-8b02-5033f952db3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6aa2ac96-fc9f-49b9-8b02-5033f952db3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

